### PR TITLE
Limit reporting for chrome-extensions, add domain to report

### DIFF
--- a/csp-logger.js
+++ b/csp-logger.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+var url = require('url');
 
 var argv = require('optimist')
   .usage('Usage: $0')
@@ -22,8 +23,8 @@ if (argv.test) {
 var store = require('./lib/store').init(config);
 
 // Rollbar
-var shouldReportToRollbar = process.env.ROLLBAR_ACCESS_TOKEN !== undefined;
-if (shouldReportToRollbar) {
+var isRollbarEnabled = process.env.ROLLBAR_ACCESS_TOKEN !== undefined;
+if (isRollbarEnabled) {
   var Rollbar = require('rollbar');
   var rollbar = new Rollbar({
     accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
@@ -34,11 +35,25 @@ if (shouldReportToRollbar) {
 
 server.listen(config.port, function (reportObject, req) {
   store.save(reportObject);
-  if (shouldReportToRollbar) {
-    rollbar.warning('CSP violation', {
-      environment: 'csp-logger',
-      deploymentKey: 'csp-logger',
-      districtKey: 'csp-logger'
-    });
+
+  if (isRollbarEnabled && shouldReportToRollbar(reportObject)) {
+    reportToRollbar(reportObject, req);
   }
 });
+
+function shouldReportToRollbar(reportObject) {
+  // Our CSP disallows chrome-extensions.  Log this but don't send to Rollbar.
+  // See https://stackoverflow.com/questions/32336860/why-would-i-get-a-csp-violation-for-the-blocked-uri-about#35559407
+  if (reportObject['blockedURI'] === 'chrome-extension') return false;
+  if (reportObject['blockedURI'] === 'about') return false;
+  return true;
+}
+
+function reportToRollbar(reportObject, req) {
+  var reportingDomain = url.parse(reportObject['document-uri']).host;
+  rollbar.warning('CSP violation from ' + reportingDomain, {
+    reportingDomain: reportingDomain,
+    deploymentKey: 'csp-logger',
+    districtKey: 'csp-logger'
+  });
+}


### PR DESCRIPTION
Log but don't report chrome-extension and about, add domain to Rollbar title and event.